### PR TITLE
DafnyArray

### DIFF
--- a/Binaries/DafnyRuntime.h
+++ b/Binaries/DafnyRuntime.h
@@ -520,6 +520,13 @@ struct hash<DafnySequence<U>> {
     }
 };
 
+template <typename U>
+struct hash<DafnyArray<U>> {
+    size_t operator()(const DafnyArray<U>& s) const {
+        return std::hash<shared_ptr<vector<U>>>()(s.vec);
+    }
+};
+
 /*********************************************************
  *  SETS                                                 *
  *********************************************************/

--- a/Binaries/DafnyRuntime.h
+++ b/Binaries/DafnyRuntime.h
@@ -291,6 +291,9 @@ struct DafnyArray {
   bool operator==(DafnyArray<T> const& other) const {
     return vec == other.vec;
   }
+
+  typename vector<T>::iterator begin() { return vec->begin(); }
+  typename vector<T>::iterator end() { return vec->end(); }
 };
 
 template<typename U>
@@ -353,14 +356,14 @@ struct DafnySequence {
       len = arr.size();
       sptr = shared_ptr<T> (new T[len], std::default_delete<T[]>());
       start = &*sptr;
-      std::copy(arr.vec->begin(), arr.vec->end(), start);
+      std::copy(arr.begin(), arr.end(), start);
     }
 
     DafnySequence(DafnyArray<T> arr, uint64 lo, uint64 hi) {
       len = hi - lo;
       sptr = shared_ptr<T> (new T[len], std::default_delete<T[]>());
       start = &*sptr;
-      std::copy(arr.vec->begin() + lo, arr.vec->begin() + hi, start);
+      std::copy(arr.begin() + lo, arr.begin() + hi, start);
     }
 
     DafnySequence(initializer_list<T> il) {

--- a/Source/Dafny/Compiler-cpp.cs
+++ b/Source/Dafny/Compiler-cpp.cs
@@ -1448,7 +1448,7 @@ namespace Microsoft.Dafny {
       return "auto " + target;
     }
 
-    protected override void EmitNull(Type type, TargetWriter wr) {
+    protected void EmitNullText(Type type, TextWriter wr) {
       var xType = type.NormalizeExpand();
       if (xType.IsArrayType) {
         ArrayClassDecl at = xType.AsArrayType;
@@ -1462,6 +1462,10 @@ namespace Microsoft.Dafny {
       } else {
         wr.Write("nullptr");
       }
+    }
+
+    protected override void EmitNull(Type type, TargetWriter wr) {
+      EmitNullText(type, wr);
     }
 
     // ----- Statements -------------------------------------------------------------
@@ -1586,19 +1590,7 @@ namespace Microsoft.Dafny {
       if (e is StaticReceiverExpr) {
         wr.Write(TypeName(e.Type, wr, e.tok));
       } else if (e.Value == null) {
-        var xType = e.Type.NormalizeExpand();
-        if (xType.IsArrayType) {
-          ArrayClassDecl at = xType.AsArrayType;
-          Contract.Assert(at != null);  // follows from xType.IsArrayType
-          Type elType = UserDefinedType.ArrayElementType(xType);
-          if (at.Dims == 1) {
-            wr.Write("DafnyArray<{0}>::Null()", TypeName(elType, wr, null));
-          } else {
-            throw NotSupported("Multi-dimensional arrays");
-          }
-        } else {
-          wr.Write("nullptr");
-        }
+        EmitNullText(e.Type, wr);
       } else if (e.Value is bool) {
         wr.Write((bool)e.Value ? "true" : "false");
       } else if (e is CharLiteralExpr) {

--- a/Source/Dafny/Compiler-cpp.cs
+++ b/Source/Dafny/Compiler-cpp.cs
@@ -1308,7 +1308,7 @@ namespace Microsoft.Dafny {
               throw NotSupported("Multi-dimensional arrays");
             }
           } else {
-            return "nullptr_2";
+            return "nullptr";
           }
         }
       } else if (cl is DatatypeDecl) {

--- a/Source/Dafny/Compiler-cpp.cs
+++ b/Source/Dafny/Compiler-cpp.cs
@@ -1299,7 +1299,17 @@ namespace Microsoft.Dafny {
         if (Attributes.ContainsBool(cl.Attributes, "handle", ref isHandle) && isHandle) {
           return "0";
         } else {
-          return "nullptr";
+          if (cl is ArrayClassDecl) {
+            var arrayClass = (ArrayClassDecl)cl;
+            Type elType = UserDefinedType.ArrayElementType(xType);
+            if (arrayClass.Dims == 1) {
+              return string.Format("DafnyArray<{0}>::Null()", TypeName(elType, wr, tok));
+            } else {
+              throw NotSupported("Multi-dimensional arrays");
+            }
+          } else {
+            return "nullptr_2";
+          }
         }
       } else if (cl is DatatypeDecl) {
         var dt = (DatatypeDecl)cl;

--- a/Source/Dafny/Compiler-cpp.cs
+++ b/Source/Dafny/Compiler-cpp.cs
@@ -1281,7 +1281,7 @@ namespace Microsoft.Dafny {
             var arrayClass = (ArrayClassDecl)((NonNullTypeDecl)td).Class;
             Type elType = UserDefinedType.ArrayElementType(xType);
             if (arrayClass.Dims == 1) {
-              return string.Format("DafnyArray<{0}>::Null()", TypeName(udt, wr, tok));
+              return string.Format("DafnyArray<{0}>::Null()", TypeName(elType, wr, tok));
             } else {
               return string.Format("_dafny.newArray(nullptr, {0})", Util.Comma(arrayClass.Dims, _ => "0"));
             }

--- a/Test/c++/Extern.h
+++ b/Test/c++/Extern.h
@@ -19,10 +19,10 @@ namespace Extern {
     public: 
 
     template <typename T>
-    static shared_ptr<vector<T>> newArrayFill(uint64 size, T v) {
-      shared_ptr<vector<T>> ret = make_shared<vector<T>>(size);
+    static DafnyArray<T> newArrayFill(uint64 size, T v) {
+      DafnyArray<T> ret = DafnyArray<T>::New(size);
       for (uint64 i = 0; i < size; i++) {
-        (*ret)[i] = v;
+        ret.at(i) = v;
       }
       return ret;
     }

--- a/Test/c++/arrays.dfy
+++ b/Test/c++/arrays.dfy
@@ -11,6 +11,23 @@ newtype{:nativeType "uint"} uint32 = i:int | 0 <= i < 0x100000000
 //newtype{:nativeType "int"} nat32 = i:int | 0 <= i < 0x80000000
 //newtype{:nativeType "long"} nat64 = i:int | 0 <= i < 0x8000000000000000
 
+method returnANullArray() returns (a: array?<uint32>)
+ensures a == null
+{
+  a := null;
+}
+
+method returnANonNullArray() returns (a: array?<uint32>)
+ensures a != null
+ensures a.Length == 5
+{
+  a := new uint32[5];
+  a[0] := 1;
+  a[1] := 2;
+  a[2] := 3;
+  a[3] := 4;
+  a[4] := 5;
+}
 
 method LinearSearch(a: array<uint32>, len:uint32, key: uint32) returns (n: uint32)
   requires a.Length == len as int
@@ -67,6 +84,14 @@ method Main() {
   print s, "\n";
 
   PrintArray<uint32>(null, 0);
+
+  print "Null array:\n";
+  var a1 := returnANullArray();
+  PrintArray<uint32>(a1, 5);
+
+  print "Non-Null array:\n";
+  var a2 := returnANonNullArray();
+  PrintArray<uint32>(a2, 5);
 }
 
 

--- a/Test/c++/arrays.dfy
+++ b/Test/c++/arrays.dfy
@@ -60,6 +60,8 @@ method PrintArray<A>(a:array?<A>, len:uint32)
   }
 }
 
+datatype ArrayDatatype = AD(ar: array<uint32>)
+
 method Main() {
   var a := new uint32[23];
   var i := 0;
@@ -92,6 +94,14 @@ method Main() {
   print "Non-Null array:\n";
   var a2 := returnANonNullArray();
   PrintArray<uint32>(a2, 5);
+
+  print "Array in datatype:\n";
+  var someAr := new uint32[3];
+  someAr[0] := 1;
+  someAr[0] := 3;
+  someAr[0] := 9;
+  var ad := AD(someAr);
+  PrintArray<uint32>(ad.ar, 3);
 }
 
 

--- a/Test/c++/arrays.expect
+++ b/Test/c++/arrays.expect
@@ -6,3 +6,7 @@
 [0, 1, 2, 3, 4, 5, 6, 7]
 [0, 1, 2, 3, 4, 5, 6, 7]
 It's null
+Null array:
+It's null
+Non-Null array:
+1 2 3 4 5 

--- a/Test/c++/arrays.expect
+++ b/Test/c++/arrays.expect
@@ -10,3 +10,5 @@ Null array:
 It's null
 Non-Null array:
 1 2 3 4 5 
+Array in datatype:
+9 0 0 

--- a/Test/c++/class.dfy
+++ b/Test/c++/class.dfy
@@ -6,23 +6,40 @@ class MyClass {
   const c:uint32 := 17
   static const d: uint32
   static const e:uint32 := 18
+
+  var ar: array<uint32>
+
   constructor (x: uint32) 
     requires x < 100;
     ensures this.a < 300;
     ensures this.b < 300;
+    ensures fresh(this.ar);
   {
     a := 100 + x;
     b := 200 + x;
+    ar := new uint32[5];
   }
 
   function method F(): uint32 { 8 }
   static function method G(): uint32 { 9 }
   method M() returns (r: uint32) { r := 69; }
   static method N() returns (r: uint32) { return 70; }
+
+  method stuffWithAr()
+  modifies this
+  modifies this.ar
+  {
+    print "stuffWithAr\n";
+    this.ar := new uint32[5];
+    this.ar[0] := 5;
+    print this.ar[0];
+    print "\n";
+  }
 }
 
 method CallEm(c: MyClass, t: MyClass, i: MyClass)
   requires c.a as int + t.a as int + i.a as int < 1000;
+  ensures c.ar == old(c.ar)
   modifies c, t, i
 {
   // instance fields
@@ -92,7 +109,8 @@ method CallEm(c: MyClass, t: MyClass, i: MyClass)
 }
 
 
-method TestMyClass() {
+method TestMyClass()
+{
   var c := new MyClass(3);
   var t := new MyClass(2);
   var i := new MyClass(2);
@@ -101,6 +119,7 @@ method TestMyClass() {
   var t3 : MyClass;
   t3 := t;
   CallEm(c, t, i);
+  c.stuffWithAr();
 }
 
 

--- a/Test/c++/class.expect
+++ b/Test/c++/class.expect
@@ -6,6 +6,8 @@
 0 18 9 70
 0 18 9 70
 0 18 9 70
+stuffWithAr
+5
 EqualityReflexive: This is expected
 ClassAndPtrDiffer: This is expected
 DeepEquality: This is expected


### PR DESCRIPTION
Wrap `shared_ptr<vector<T>>` in a `DafnyArray` struct.

This leads to slightly cleaner code, and it will make it easier to experiment with alternate `DafnyArray` implementations by modifying DafnyRuntime.h.

Regarding the code, I didn't totally know what I was doing... I had to write the code that emits `DafnyArray<T>::Null()` twice because there was one place that wanted it with a TextWriter and another place that wanted it with a TargetWriter and I didn't know what the relationship between these was.

And at one point, I needed some kind of Token object but I didn't have one, so I just passed null, and I have no idea if that was okay.