### PR TITLE
fix a few portability issues

### DIFF
--- a/Binaries/DafnyRuntime.h
+++ b/Binaries/DafnyRuntime.h
@@ -329,13 +329,6 @@ struct DafnySequence {
       this->len = len;
     }
 
-    explicit DafnySequence<char>(string const& s) {
-      len = s.size();
-      sptr = shared_ptr<char> (new char[len], std::default_delete<char[]>());
-      memcpy(&*sptr, s.c_str(), s.size());
-      start = &*sptr;
-    }
-
     DafnySequence(const DafnySequence<T>& other) {
       sptr = other.sptr;
       start = other.start;
@@ -471,6 +464,12 @@ struct DafnySequence {
     // TODO: toString
 };
 
+inline DafnySequence<char> DafnySequenceFromString(string const& s) {
+  DafnySequence<char> seq(s.size());
+  memcpy(seq.ptr(), &s[0], s.size());
+  return seq;
+}
+
 template <typename T>
 std::ostream& operator<<(std::ostream& os, const DafnySequence<T>& s)
 {
@@ -510,7 +509,7 @@ inline ostream& operator<<(ostream& out, const DafnySequence<char>& val){
 }
 
 template <typename U>
-struct hash<DafnySequence<U>> {
+struct std::hash<DafnySequence<U>> {
     size_t operator()(const DafnySequence<U>& s) const {
         size_t seed = 0;
         for (size_t i = 0; i < s.size(); i++) {      
@@ -521,7 +520,7 @@ struct hash<DafnySequence<U>> {
 };
 
 template <typename U>
-struct hash<DafnyArray<U>> {
+struct std::hash<DafnyArray<U>> {
     size_t operator()(const DafnyArray<U>& s) const {
         return std::hash<shared_ptr<vector<U>>>()(s.vec);
     }
@@ -649,7 +648,7 @@ inline ostream& operator<<(ostream& out, const DafnySet<U>& val){
 }
 
 template <typename U>
-struct hash<DafnySet<U>> {
+struct std::hash<DafnySet<U>> {
     size_t operator()(const DafnySet<U>& s) const {
         size_t seed = 0;
         for (auto const& elt:s.set) {      
@@ -805,7 +804,7 @@ inline ostream& operator<<(ostream& out, const DafnyMap<T,U>& val){
 }
 
 template <typename T, typename U>
-struct hash<DafnyMap<T,U>> {
+struct std::hash<DafnyMap<T,U>> {
     size_t operator()(const DafnyMap<T,U>& s) const {
         size_t seed = 0;
         for (auto const& kv:s.map) {      

--- a/Source/Dafny/Compiler-cpp.cs
+++ b/Source/Dafny/Compiler-cpp.cs
@@ -439,7 +439,7 @@ namespace Microsoft.Dafny {
         // Define a custom hasher
         hashWr.WriteLine("template <{0}>", TypeParameters(dt.TypeArgs));
         var fullName = dt.Module.CompileName + "::" + DtT_protected + TemplateMethod(dt.TypeArgs);
-        var hwr = hashWr.NewBlock(string.Format("struct hash<{0}>", fullName), ";");
+        var hwr = hashWr.NewBlock(string.Format("struct std::hash<{0}>", fullName), ";");
         var owr = hwr.NewBlock(string.Format("std::size_t operator()(const {0}& x) const", fullName));
         owr.WriteLine("size_t seed = 0;");
         foreach (var arg in ctor.Formals) {
@@ -496,7 +496,7 @@ namespace Microsoft.Dafny {
           // Define a custom hasher
           hashWr.WriteLine("template <{0}>", TypeParameters(dt.TypeArgs));
           var fullName = dt.Module.CompileName + "::" + structName + TemplateMethod(dt.TypeArgs);
-          var hwr = hashWr.NewBlock(string.Format("struct hash<{0}>", fullName), ";");
+          var hwr = hashWr.NewBlock(string.Format("struct std::hash<{0}>", fullName), ";");
           var owr = hwr.NewBlock(string.Format("std::size_t operator()(const {0}& x) const", fullName));
           owr.WriteLine("size_t seed = 0;");
           int argCount = 0;
@@ -641,7 +641,7 @@ namespace Microsoft.Dafny {
         // Define a custom hasher for the struct as a whole
         hashWr.WriteLine("template <{0}>", TypeParameters(dt.TypeArgs));
         var fullStructName = dt.Module.CompileName + "::" + DtT_protected;
-        var hwr2 = hashWr.NewBlock(string.Format("struct hash<{0}{1}>", fullStructName, TemplateMethod(dt.TypeArgs)), ";");
+        var hwr2 = hashWr.NewBlock(string.Format("struct std::hash<{0}{1}>", fullStructName, TemplateMethod(dt.TypeArgs)), ";");
         var owr2 = hwr2.NewBlock(string.Format("std::size_t operator()(const {0}{1}& x) const", fullStructName, TemplateMethod(dt.TypeArgs)));
         owr2.WriteLine("size_t seed = 0;");
         owr2.WriteLine("hash_combine<uint64>(seed, (uint64)x.tag);");
@@ -654,9 +654,9 @@ namespace Microsoft.Dafny {
         if (IsRecursiveDatatype(dt)) {
           // Emit a custom hasher for a pointer to this type
           hashWr.WriteLine("template <{0}>", TypeParameters(dt.TypeArgs));
-          hwr2 = hashWr.NewBlock(string.Format("struct hash<shared_ptr<{0}{1}>>", fullStructName, TemplateMethod(dt.TypeArgs)), ";");
+          hwr2 = hashWr.NewBlock(string.Format("struct std::hash<shared_ptr<{0}{1}>>", fullStructName, TemplateMethod(dt.TypeArgs)), ";");
           owr2 = hwr2.NewBlock(string.Format("std::size_t operator()(const shared_ptr<{0}{1}>& x) const", fullStructName, TemplateMethod(dt.TypeArgs)));
-          owr2.WriteLine("struct hash<{0}{1}> hasher;", fullStructName, TemplateMethod(dt.TypeArgs));
+          owr2.WriteLine("struct std::hash<{0}{1}> hasher;", fullStructName, TemplateMethod(dt.TypeArgs));
           owr2.WriteLine("std::size_t h = hasher(*x);");
           owr2.WriteLine("return h;");
         }
@@ -1668,7 +1668,7 @@ namespace Microsoft.Dafny {
 
     protected override void EmitStringLiteral(string str, bool isVerbatim, TextWriter wr) {
       var n = str.Length;
-      wr.Write("DafnySequence<char>(");
+      wr.Write("DafnySequenceFromString(");
       if (!isVerbatim) {
         wr.Write("\"{0}\"", str);
       } else {


### PR DESCRIPTION
- Apparently we can't declare specialized constructors like `DafnySequence<char>`. My friend gave me a very complicated real way to do it, but I decided to just make it a function outside the class.

- `hash` needs to be qualified as `std::hash`.

Depends on my other PR.