### PR TITLE
[groebner-extension]: close query file after writing

### DIFF
--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -290,6 +290,7 @@ namespace Microsoft.Dafny {
         writer.WriteLine("// {0} = {1};", e.Value, e.Key);
       }
       writer.Flush();
+      writer.Close();
       return queryFileName;
     }
 


### PR DESCRIPTION
close the `queryFile` for Singular solver. Otherwise there will be IOException error when deleting it on Windows.